### PR TITLE
fix: PIZ-1 I cant create an order

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -22,6 +22,14 @@ def update_size():
     return jsonify(response), status_code
 
 
+@size.route('/', methods=GET)
+def get_all_sizes():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code
+
+
 @size.route('/id/<_id>', methods=GET)
 def get_size_by_id(_id: int):
     size, error = SizeController.get_by_id(_id)


### PR DESCRIPTION
#### 🤔 Why?

An order can not be created correctly and the pizza's size does not appear, so the client can not order a pizza. With this change, the client can order a pizza, and see the available sizes.

#### 🛠 What I changed:

- app/services/size.py: include the endpoint to get all the available sizes.

#### 🗃️ Trello Issues:

[PIZ1 - I can't create an order (Bug)](https://trello.com/c/F5pSIWqA)
